### PR TITLE
kafka-topic-change

### DIFF
--- a/health-check/index.js
+++ b/health-check/index.js
@@ -35,7 +35,7 @@ async function healthCheckHandler(config, basicCheck = false, currentServiceName
 	if (config?.checks?.kafka?.enabled) {
 		try {
 			const kafka = require('./services/kafka')
-			const healthy = await kafka.check(config.checks.kafka.url)
+			const healthy = await kafka.check(config.checks.kafka.url,config.checks.kafka.topic)
 			checks.push(serviceResult('Kafka', healthy))
 		} catch (err) {
 			checks.push(serviceResult('Kafka', false))

--- a/health-check/index.js
+++ b/health-check/index.js
@@ -35,7 +35,7 @@ async function healthCheckHandler(config, basicCheck = false, currentServiceName
 	if (config?.checks?.kafka?.enabled) {
 		try {
 			const kafka = require('./services/kafka')
-			const healthy = await kafka.check(config.checks.kafka.url,config.checks.kafka.topic)
+			const healthy = await kafka.check(config.checks.kafka.url, config.checks.kafka.topic)
 			checks.push(serviceResult('Kafka', healthy))
 		} catch (err) {
 			checks.push(serviceResult('Kafka', false))
@@ -67,14 +67,11 @@ async function healthCheckHandler(config, basicCheck = false, currentServiceName
 	// Check BullMQ (Redis-backed job queue) if enabled
 	if (config?.checks?.bullmq?.enabled) {
 		try {
-			const bullmq = require('./services/bullmq');
-			const healthy = await bullmq.check(
-				config.checks.bullmq.redisHost,
-				config.checks.bullmq.redisPort
-			);
-			checks.push(serviceResult('bullmq', healthy));
+			const bullmq = require('./services/bullmq')
+			const healthy = await bullmq.check(config.checks.bullmq.redisHost, config.checks.bullmq.redisPort)
+			checks.push(serviceResult('bullmq', healthy))
 		} catch (err) {
-			checks.push(serviceResult('bullmq', false));
+			checks.push(serviceResult('bullmq', false))
 		}
 	}
 
@@ -107,7 +104,6 @@ async function healthCheckHandler(config, basicCheck = false, currentServiceName
 
 	return formatResponse(result)
 }
-
 
 /**
  * Create a service result object from the health check status.
@@ -157,6 +153,15 @@ function validateHealthConfig(config) {
 	for (const { name, value } of basicServices) {
 		if (value?.enabled && !value.url) {
 			throw new Error(`Missing 'url' for enabled service: ${name}`)
+		}
+	}
+	// Validate Kafka (needs both url and topic)
+	if (kafka?.enabled) {
+		if (!kafka.url) {
+			throw new Error("Missing 'url' for enabled service: kafka")
+		}
+		if (!kafka.topic) {
+			throw new Error("Missing 'topic' for enabled service: kafka")
 		}
 	}
 

--- a/health-check/package.json
+++ b/health-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elevate-services-health-check",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Package that can be used for service health check",
   "main": "index.js",
   "scripts": {

--- a/health-check/services/kafka.js
+++ b/health-check/services/kafka.js
@@ -8,8 +8,6 @@
 const kafka = require('kafka-node');
 const { v4: uuidv4 } = require('uuid');
 
-const TOPIC_NAME = 'health-check-topic-check';
-
 function ensureTopicExists(client, topicName) {
 	return new Promise((resolve, reject) => {
 		client.loadMetadataForTopics([], (error, results) => {
@@ -48,13 +46,13 @@ function ensureTopicExists(client, topicName) {
 	});
 }
 
-async function check(kafkaUrl) {
+async function check(kafkaUrl,topicName) {
 	return new Promise(async (resolve) => {
 		console.log(`[Kafka Health Check] Connecting to Kafka at ${kafkaUrl}`);
 		const client = new kafka.KafkaClient({ kafkaHost: kafkaUrl });
 
 		try {
-			await ensureTopicExists(client, TOPIC_NAME);
+			await ensureTopicExists(client, topicName);
 		} catch (err) {
 			client.close();
 			return resolve(false);
@@ -63,7 +61,7 @@ async function check(kafkaUrl) {
 		const messageId = `health-check-${uuidv4()}`;
 		const payloads = [
 			{
-				topic: TOPIC_NAME,
+				topic: topicName,
 				messages: messageId,
 			},
 		];
@@ -84,7 +82,7 @@ async function check(kafkaUrl) {
 
 				const consumer = new kafka.Consumer(
 					client,
-					[{ topic: TOPIC_NAME, partition: 0 }],
+					[{ topic: topicName, partition: 0 }],
 					{
 						autoCommit: true,
 						fromOffset: false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Kafka health check now supports a configurable topic and can be targeted via configuration.
- Bug Fixes
  - Health check configuration validation now requires both Kafka URL and topic when Kafka is enabled.
- Chores
  - Package version updated to 0.0.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->