### PR TITLE
added-group-id

### DIFF
--- a/health-check/index.js
+++ b/health-check/index.js
@@ -163,6 +163,9 @@ function validateHealthConfig(config) {
 		if (!kafka.topic) {
 			throw new Error("Missing 'topic' for enabled service: kafka")
 		}
+		if (!kafka.groupId) {
+			throw new Error("Missing 'groupId' for enabled service: kafka")
+		}
 	}
 
 	if (Array.isArray(microservices)) {

--- a/health-check/package.json
+++ b/health-check/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elevate-services-health-check",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Package that can be used for service health check",
   "main": "index.js",
   "scripts": {

--- a/health-check/services/kafka.js
+++ b/health-check/services/kafka.js
@@ -48,9 +48,9 @@ function ensureTopicExists(client, topicName) {
 
 async function check(kafkaUrl,topicName,groupId) {
 	return new Promise(async (resolve) => {
-
-		let uniqueTopicName = topicName + process.pid
-		let uniqueGroupId = groupId + process.pid
+		const pidSuffix = `-${process.pid}`;
+		const uniqueTopicName = `${topicName}${pidSuffix}`;
+		const uniqueGroupId = `${groupId}${pidSuffix}`;
 		console.log(`[Kafka Health Check] Connecting to Kafka at ${kafkaUrl}`);
 		const client = new kafka.KafkaClient({ kafkaHost: kafkaUrl });
 

--- a/health-check/services/kafka.js
+++ b/health-check/services/kafka.js
@@ -46,13 +46,16 @@ function ensureTopicExists(client, topicName) {
 	});
 }
 
-async function check(kafkaUrl,topicName) {
+async function check(kafkaUrl,topicName,groupId) {
 	return new Promise(async (resolve) => {
+
+		let uniqueTopicName = topicName + process.pid
+		let uniqueGroupId = groupId + process.pid
 		console.log(`[Kafka Health Check] Connecting to Kafka at ${kafkaUrl}`);
 		const client = new kafka.KafkaClient({ kafkaHost: kafkaUrl });
 
 		try {
-			await ensureTopicExists(client, topicName);
+			await ensureTopicExists(client, uniqueTopicName);
 		} catch (err) {
 			client.close();
 			return resolve(false);
@@ -61,7 +64,7 @@ async function check(kafkaUrl,topicName) {
 		const messageId = `health-check-${uuidv4()}`;
 		const payloads = [
 			{
-				topic: topicName,
+				topic: uniqueTopicName,
 				messages: messageId,
 			},
 		];
@@ -82,8 +85,9 @@ async function check(kafkaUrl,topicName) {
 
 				const consumer = new kafka.Consumer(
 					client,
-					[{ topic: topicName, partition: 0 }],
+					[{ topic: uniqueTopicName, partition: 0 }],
 					{
+						groupId: uniqueGroupId, 
 						autoCommit: true,
 						fromOffset: false,
 					}

--- a/health-check/services/kafka.js
+++ b/health-check/services/kafka.js
@@ -88,7 +88,6 @@ async function check(kafkaUrl,topicName,groupId) {
 					[{ topic: uniqueTopicName, partition: 0 }],
 					{
 						groupId: uniqueGroupId, 
-						autoCommit: true,
 						fromOffset: false,
 					}
 				);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kafka health check now requires groupId when Kafka is enabled; missing groupId returns a clear validation error and stops checks.
  * Kafka health check isolates each process by using unique per-process topic and consumer-group identifiers to avoid cross-process collisions.
* **Chores**
  * Health-check package version bumped to 0.0.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->