### PR TITLE
routes updated for org-policy in project-service

### DIFF
--- a/elevate-project/constants/routes.js
+++ b/elevate-project/constants/routes.js
@@ -3220,6 +3220,66 @@ module.exports = {
 				type: "POST"
 			},
             service: "project"
-		}
+		},
+        {
+            sourceRoute: "/project/v1/organizationExtension/eventListener",
+            type: "POST",
+            inSequence: false,
+            targetRoute: {
+				path: "/project/v1/organizationExtension/eventListener",
+				type: "POST"
+			},
+            service: "project"
+        },
+        {
+            sourceRoute: "/project/v1/organizationExtension/update",
+            type: "POST",
+            inSequence: false,
+            targetRoute: {
+				path: "/project/v1/organizationExtension/update",
+				type: "POST"
+			},
+            service: "project"
+        },
+        {
+            sourceRoute: "/project/v1/organizationExtension/update/:id",
+            type: "POST",
+            inSequence: false,
+            targetRoute: {
+				path: "/project/v1/organizationExtension/update/:id",
+				type: "POST"
+			},
+            service: "project"
+        },
+        {
+            sourceRoute: "/project/v1/organizationExtension/update",
+            type: "PATCH",
+            inSequence: false,
+            targetRoute: {
+				path: "/project/v1/organizationExtension/update",
+				type: "POST"
+			},
+            service: "project"
+        },
+        {
+            sourceRoute: "/project/v1/organizationExtension/update/:id",
+            type: "PATCH",
+            inSequence: false,
+            targetRoute: {
+				path: "/project/v1/organizationExtension/update/:id",
+				type: "POST"
+			},
+            service: "project"
+        },
+        {
+            sourceRoute: "/project/v1/admin/updateRelatedOrgs",
+            type: "POST",
+            inSequence: false,
+            targetRoute: {
+				path: "/project/v1/admin/updateRelatedOrgs",
+				type: "POST"
+			},
+            service: "project"
+        }  
     ]
 }

--- a/elevate-project/package.json
+++ b/elevate-project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elevate-project",
-  "version": "1.1.47",
+  "version": "1.1.48",
   "description": "Npm package for Elevate-Project service integration with Interface service",
   "main": "index.js",
   "scripts": {

--- a/interface-routes/elevate-dev-routes.json
+++ b/interface-routes/elevate-dev-routes.json
@@ -13668,6 +13668,90 @@
 				}
 			],
 			"service": "self-creation-portal"
+		},
+		{
+			"sourceRoute": "/project/v1/organizationExtension/eventListener",
+			"type": "POST",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "project",
+					"packageName": "elevate-project"
+				}
+			],
+			"service": "project"
+		},
+		{
+			"sourceRoute": "/project/v1/organizationExtension/update",
+			"type": "POST",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "project",
+					"packageName": "elevate-project"
+				}
+			],
+			"service": "project"
+		},
+		{
+			"sourceRoute": "/project/v1/organizationExtension/update/:id",
+			"type": "POST",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "project",
+					"packageName": "elevate-project"
+				}
+			],
+			"service": "project"
+		},
+		{
+			"sourceRoute": "/project/v1/organizationExtension/update",
+			"type": "PATCH",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "project",
+					"packageName": "elevate-project"
+				}
+			],
+			"service": "project"
+		},
+		{
+			"sourceRoute": "/project/v1/organizationExtension/update/:id",
+			"type": "PATCH",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "project",
+					"packageName": "elevate-project"
+				}
+			],
+			"service": "project"
+		},
+		{
+			"sourceRoute": "/project/v1/admin/updateRelatedOrgs",
+			"type": "POST",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "project",
+					"packageName": "elevate-project"
+				}
+			],
+			"service": "project"
 		}
 	]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added API endpoints under /project/v1/organizationExtension:
    - POST /eventListener
    - POST/PATCH /update
    - POST/PATCH /update/:id
  - Added admin endpoint: POST /project/v1/admin/updateRelatedOrgs
  - These routes are now available for client use.

- Chores
  - Version bump to 1.1.48.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->