### PR TITLE
survey library and orgPolicies routes added

### DIFF
--- a/elevate-survey/constants/routes.js
+++ b/elevate-survey/constants/routes.js
@@ -3009,6 +3009,128 @@ module.exports = {
             },
             service: "survey"
         },
+
+        {
+            sourceRoute: "/survey/v1/library/categories/create",
+            type: "POST",
+            inSequence: false,
+            targetRoute: {
+                path: "/survey/v1/library/categories/create",
+                type: "POST"
+            },
+            service: "survey"
+        },
+		{
+            sourceRoute: "/survey/v1/library/categories/update",
+            type: "POST",
+            inSequence: false,
+            targetRoute: {
+                path: "/survey/v1/library/categories/update",
+                type: "POST"
+            },
+            service: "survey"
+        },
+		{
+            sourceRoute: "/survey/v1/library/categories/update/:id",
+            type: "POST",
+            inSequence: false,
+            targetRoute: {
+                path: "/survey/v1/library/categories/update/:id",
+                type: "POST"
+            },
+            service: "survey"
+        },
+		{
+            sourceRoute: "/survey/v1/library/categories/list",
+            type: "GET",
+            inSequence: false,
+            targetRoute: {
+                path: "/survey/v1/library/categories/list",
+                type: "GET"
+            },
+            service: "survey"
+        },
+		{
+            sourceRoute: "/survey/v1/library/surveys/list",
+            type: "GET",
+            inSequence: false,
+            targetRoute: {
+                path: "/survey/v1/library/surveys/list",
+                type: "GET"
+            },
+            service: "survey"
+        },
+		{
+            sourceRoute: "/survey/v1/library/observations/list",
+            type: "GET",
+            inSequence: false,
+            targetRoute: {
+                path: "/survey/v1/library/observations/list",
+                type: "GET"
+            },
+            service: "survey"
+        },
+		{
+            sourceRoute: "/survey/v1/library/observations/import",
+            type: "POST",
+            inSequence: false,
+            targetRoute: {
+                path: "/survey/v1/library/observations/import",
+                type: "POST"
+            },
+            service: "survey"
+        },
+		{
+            sourceRoute: "/survey/v1/library/observations/import/:id",
+            type: "POST",
+            inSequence: false,
+            targetRoute: {
+                path: "/survey/v1/library/observations/import/:id",
+                type: "POST"
+            },
+            service: "survey"
+        },
+		{
+            sourceRoute: "/survey/v1/organizationExtension/create",
+            type: "POST",
+            inSequence: false,
+            targetRoute: {
+                path: "/survey/v1/organizationExtension/create",
+                type: "POST"
+            },
+            service: "survey"
+        },
+		{
+            sourceRoute: "/survey/v1/organizationExtension/update",
+            type: "POST",
+            inSequence: false,
+            targetRoute: {
+                path: "/survey/v1/organizationExtension/update",
+                type: "POST"
+            },
+            service: "survey"
+        },
+		{
+            sourceRoute: "/survey/v1/organizationExtension/update/:id",
+            type: "POST",
+            inSequence: false,
+            targetRoute: {
+                path: "/survey/v1/organizationExtension/update/:id",
+                type: "POST"
+            },
+            service: "survey"
+        },
+		{
+            sourceRoute: "/survey/v1/organizationExtension/updateRelatedOrgs",
+            type: "POST",
+            inSequence: false,
+            targetRoute: {
+                path: "/survey/v1/organizationExtension/updateRelatedOrgs",
+                type: "POST"
+            },
+            service: "survey"
+        },
+
 	],
 }
 

--- a/elevate-survey/package.json
+++ b/elevate-survey/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "elevate-survey-observation",
-	"version": "1.0.17",
+	"version": "1.0.18",
 	"description": "Npm package for Elevate-survey-observation service integration with Interface service",
 	"main": "index.js",
 	"scripts": {

--- a/interface-routes/elevate-dev-routes.json
+++ b/interface-routes/elevate-dev-routes.json
@@ -12062,6 +12062,174 @@
 			"service": "survey"
 		},
 		{
+			"sourceRoute": "/survey/v1/library/categories/create",
+			"type": "POST",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "survey",
+					"packageName": "elevate-survey-observation"
+				}
+			],
+			"service": "survey"
+		},
+		{
+			"sourceRoute": "/survey/v1/library/categories/update",
+			"type": "POST",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "survey",
+					"packageName": "elevate-survey-observation"
+				}
+			],
+			"service": "survey"
+		},
+		{
+			"sourceRoute": "/survey/v1/library/categories/update/:id",
+			"type": "POST",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "survey",
+					"packageName": "elevate-survey-observation"
+				}
+			],
+			"service": "survey"
+		},
+		{
+			"sourceRoute": "/survey/v1/library/categories/list",
+			"type": "GET",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "survey",
+					"packageName": "elevate-survey-observation"
+				}
+			],
+			"service": "survey"
+		},
+		{
+			"sourceRoute": "/survey/v1/library/surveys/list",
+			"type": "GET",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "survey",
+					"packageName": "elevate-survey-observation"
+				}
+			],
+			"service": "survey"
+		},
+		{
+			"sourceRoute": "/survey/v1/library/observations/list",
+			"type": "GET",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "survey",
+					"packageName": "elevate-survey-observation"
+				}
+			],
+			"service": "survey"
+		},
+		{
+			"sourceRoute": "/survey/v1/library/observations/import",
+			"type": "POST",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "survey",
+					"packageName": "elevate-survey-observation"
+				}
+			],
+			"service": "survey"
+		},
+		{
+			"sourceRoute": "/survey/v1/library/observations/import/:id",
+			"type": "POST",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "survey",
+					"packageName": "elevate-survey-observation"
+				}
+			],
+			"service": "survey"
+		},
+		{
+			"sourceRoute": "/survey/v1/organizationExtension/create",
+			"type": "POST",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "survey",
+					"packageName": "elevate-survey-observation"
+				}
+			],
+			"service": "survey"
+		},
+		{
+			"sourceRoute": "/survey/v1/organizationExtension/update",
+			"type": "POST",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "survey",
+					"packageName": "elevate-survey-observation"
+				}
+			],
+			"service": "survey"
+		},
+		{
+			"sourceRoute": "/survey/v1/organizationExtension/update/:id",
+			"type": "POST",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "survey",
+					"packageName": "elevate-survey-observation"
+				}
+			],
+			"service": "survey"
+		},
+		{
+			"sourceRoute": "/survey/v1/organizationExtension/updateRelatedOrgs",
+			"type": "POST",
+			"priority": "MUST_HAVE",
+			"inSequence": false,
+			"orchestrated": false,
+			"targetPackages": [
+				{
+					"basePackageName": "survey",
+					"packageName": "elevate-survey-observation"
+				}
+			],
+			"service": "survey"
+		},
+		{
 			"sourceRoute": "/mentoring/v1/users/delete",
 			"type": "POST",
 			"priority": "MUST_HAVE",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced survey library endpoints: categories create/update/update by ID/list; surveys list; observations list/import (with optional ID); and organization extension create/update/update by ID/update related orgs.
  - Enabled these endpoints in development routing to ensure consistent access and behavior.
- Chores
  - Bumped package version to 1.0.18.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->